### PR TITLE
Support custom cmd, including chaining requests

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
+default_curl_cmd: "/usr/bin/curl"
 default_curl_args: "-fsS -m 10"
 default_schedule: "minutely"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -16,24 +16,18 @@
         mode: "0664"
         line: "OK"
 
-    - name: "Simulate a remote HTTP server on localhost - localhost-test-zero"
+    - name: "Simulate remote HTTP server(s) directly on localhost"
       changed_when: false
       async: 1
       poll: 0
       args:
         chdir: "/test"
+      loop:
+        - 8080
+        - 8081
+        - 8082
       ansible.builtin.shell:
-        cmd: nohup python3 -m http.server 8080 </dev/null >/dev/null 2>&1 &
-        executable: /bin/bash
-
-    - name: "Simulate a remote HTTP server on localhost - localhost-test-one"
-      changed_when: false
-      async: 1
-      poll: 0
-      args:
-        chdir: "/test"
-      ansible.builtin.shell:
-        cmd: nohup python3 -m http.server 8081 </dev/null >/dev/null 2>&1 &
+        cmd: nohup python3 -m http.server {{ item }} </dev/null >/dev/null 2>&1 &
         executable: /bin/bash
 
   roles:
@@ -45,3 +39,7 @@
         - label: "localhost-test-one"
           url: "http://127.0.0.1:8081"
           schedule: hourly
+        - label: "localhost-test-chained-curl"
+          curl_cmd: '/usr/bin/curl "http://127.0.0.1:8081" && /usr/bin/curl'
+          url: "http://127.0.0.1:8082"
+          schedule: minutely

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -68,7 +68,7 @@
         success_msg: "Service has exited with a 0/SUCCESS status"
         fail_msg: "Unexpected service status code: '{{ service_one.status.ExecMainStatus }}'"
 
-    - name: "Check the service status - chained-curl"
+    - name: "Check the service status - localhost-test-chained-curl"
       register: service_chained_curl
       ansible.builtin.systemd:
         name: "curl-localhost-test-chained-curl.service"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -4,6 +4,8 @@
   gather_facts: false
 
   tasks:
+    # Verify the systemd timers
+
     - name: "Check the timer status - localhost-test-zero"
       register: timer_zero
       ansible.builtin.systemd:
@@ -28,7 +30,21 @@
         success_msg: "Timer is running"
         fail_msg: "Unexpected timer state: '{{ timer_one.status.ActiveState }}'"
 
-    - name: "Check the service status"
+    - name: "Check the timer status - localhost-test-chained-curl"
+      register: timer_chained_curl
+      ansible.builtin.systemd:
+        name: "curl-localhost-test-chained-curl.timer"
+
+    - name: "Assert that the localhost-test-chained-curl timer is running"
+      ansible.builtin.assert:
+        that:
+          - timer_chained_curl.status.ActiveState == "active"
+        success_msg: "Timer is running"
+        fail_msg: "Unexpected timer state: '{{ timer_chained_curl.status.ActiveState }}'"
+
+    ## Verify the systemd services
+
+    - name: "Check the service status - zero"
       register: service_zero
       ansible.builtin.systemd:
         name: "curl-localhost-test-zero.service"
@@ -40,7 +56,7 @@
         success_msg: "Service has exited with a 0/SUCCESS status"
         fail_msg: "Unexpected service status code: '{{ service_zero.status.ExecMainStatus }}'"
 
-    - name: "Check the service status"
+    - name: "Check the service status - one"
       register: service_one
       ansible.builtin.systemd:
         name: "curl-localhost-test-one.service"
@@ -51,3 +67,15 @@
           - 'service_one.status.ExecMainStatus == "0"'
         success_msg: "Service has exited with a 0/SUCCESS status"
         fail_msg: "Unexpected service status code: '{{ service_one.status.ExecMainStatus }}'"
+
+    - name: "Check the service status - chained-curl"
+      register: service_chained_curl
+      ansible.builtin.systemd:
+        name: "curl-localhost-test-chained-curl.service"
+
+    - name: "Assert that the localhost-test-chained-curl service exited with a 0/SUCCESS status"
+      ansible.builtin.assert:
+        that:
+          - 'service_chained_curl.status.ExecMainStatus == "0"'
+        success_msg: "Service has exited with a 0/SUCCESS status"
+        fail_msg: "Unexpected service status code: '{{ service_chained_curl.status.ExecMainStatus }}'"

--- a/tasks/deploy-service.yml
+++ b/tasks/deploy-service.yml
@@ -3,6 +3,7 @@
   vars:
     label: "{{ job.label }}"
     url: "{{ job.url }}"
+    curl_cmd: "{{ job.curl_cmd | default(default_curl_cmd) }}"
     curl_args: "{{ job.curl_args | default(default_curl_args) }}"
   register: service
   ansible.builtin.template:

--- a/templates/placeholder.service
+++ b/templates/placeholder.service
@@ -4,7 +4,7 @@ After=network.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl {{ curl_args }} "{{ url }}"
+ExecStart={{ curl_cmd }} {{ curl_args }} "{{ url }}"
 Restart=no 
 
 # Security hardening


### PR DESCRIPTION
- **Allow for using custom curl commands**
- **Update the Molecule test suit**

Use cases:

- chain two curl requests (useful for heartbeats)
- use curl from a non-standard location